### PR TITLE
Complete Swedish (sv) translation with missing accessibility keys

### DIFF
--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -302,5 +302,14 @@
 	"TUTORIAL_WELCOME_BENEFIT_1": "Lär dig genom att spela - snabba praktiska steg",
 	"TUTORIAL_WELCOME_BENEFIT_2": "Användbara tips för att vägleda ditt nästa drag",
 	"TUTORIAL_WELCOME_BENEFIT_3": "Hoppa över när som helst och gå direkt till ett spel",
-	"TUTORIAL_WELCOME_START": "Starta handledning"
+	"TUTORIAL_WELCOME_START": "Starta handledning",
+	"TILE_LABEL": "{{name}}, lager {{layer}}",
+	"TILE_LABEL_HINTED": "{{name}}, lager {{layer}}, matchande par",
+	"ANNOUNCE_MATCHED": "Matchade. {{remaining}} stenar kvar.",
+	"ANNOUNCE_HINT_PAIRS": "{{count}} matchande par markerade.",
+	"ANNOUNCE_HINT_NONE": "Inga matchande par tillgängliga.",
+	"ANNOUNCE_SHUFFLE": "Stenar blandade.",
+	"ANNOUNCE_UNDO": "Senaste drag ångrat.",
+	"ANNOUNCE_GAME_WON": "Grattis, du klarade spelbrädet!",
+	"ANNOUNCE_GAME_LOST": "Inga fler matchande stenar. Spelet är slut."
 }


### PR DESCRIPTION
Adds 9 missing keys required for screen reader support:

- `TILE_LABEL` / `TILE_LABEL_HINTED` — tile labels read by screen readers
- `ANNOUNCE_MATCHED` — announces a match and remaining tile count
- `ANNOUNCE_HINT_PAIRS` — announces highlighted pairs after hint
- `ANNOUNCE_HINT_NONE` — announces when no pairs are available
- `ANNOUNCE_SHUFFLE` — announces tile shuffle
- `ANNOUNCE_UNDO` — announces last move undone
- `ANNOUNCE_GAME_WON` / `ANNOUNCE_GAME_LOST` — end-of-game announcements

All translations use vocabulary already established in `sv.json` (e.g. *stenar* for tiles, *lager* for layer, *Grattis* for congratulations).